### PR TITLE
Add Snow Engineering public API repository.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Snow Engineering Resources
+A public repository of useful tools, data, and resources for Snow College engineering students.
+
+<br>
+
+# Index
+- [Public API List](publicApis.md)
+  > A list of APIs for accessing a variety of databases and tools. Includes HTTPS status, authentication requirements, and brief description of the API.

--- a/publicApis.md
+++ b/publicApis.md
@@ -6,4 +6,22 @@
 
 | HTTPs? | API | Description | Auth/Key? |
 |:---:|:---|:---|:--:|
-|     |    |    |    |
+|  |[Chuck Norris Joke API](http://www.icndb.com/api)| | |
+|  |[Congress](https://api.congress.gov/)| | |
+|  |[Flight and Satellite Data](https://aviation-edge.com)| | |
+|  |[ISBN Database](https://isbndb.com/apidocs)| | |
+|  |[List of APIs](https://apilist.fun)| | |
+|  |[National Weather Service](https://www.weather.gov/documentation/services-web-api)| | 
+|  |[Open Movie Database](http://www.omdbapi.com)| | |
+|  |[PokeAPI](https://pokeapi.co)| | |
+|  |[Random User Generator ](https://randomuser.me)| | |
+|  |[SpaceX — GraphQL Visual API](https://api.spacex.land) <br> [SpaceX — REST API](https://api.spacex.land/rest) <br> [SpaceX — Docs v4 (Latest)](https://github.com/r-spacex/SpaceX-API/tree/master/docs#rspacex-api-docs) <br> [SpaceX — Docs v3 (Depreciated)](https://docs.spacexdata.com)| | |
+|  |[Star Trek API](http://stapi.co)| | |
+|  |[Stock Photography](https://unsplash.com/developers)| | |
+|  |[Sunrise/Sunset](https://sunrise-sunset.org/api)| | |
+|  |[Text Casing / Number Conversion](http://www.dataaccess.com/webservicesserver/TextCasing.wso)| | |
+|  |[The Cat API](https://thecatapi.com)| | |
+|  |[The Met Collection](https://www.metmuseum.org/blogs/now-at-the-met/2018/met-collection-api)| | |
+|  |[The Movie DB](https://www.themoviedb.org/settings/api)| | |
+|  |[Twilio Look-up API](https://www.twilio.com/docs/lookup/api)| | |
+|  |[Walmart](https://developer.walmart.com)| | |

--- a/publicApis.md
+++ b/publicApis.md
@@ -2,32 +2,38 @@
 
 > The APIs below are accessible for use in assignments or personal projects where you need to interact with a 3rd party API.
 
-- - - -
+## Index
+- [API List](#api-list)
+- [Useful Links](#useful-links)
 
-| HTTPs? | Key Required? | API | Description |
+<br>
+
+## API List
+| HTTPS? | Key Required? | API | Description |
 |:---:|:---:|:---|:--|
-| ✅ | ❌ | [Chuck Norris Joke API](https://www.icndb.com/api)| |
-| ✅ | ✅ | [Congress](https://api.congress.gov/)| |
-| ✅ | ✅ | [Flight and Satellite Data](https://aviation-edge.com)| |
-| ✅ | ✅ | [ISBN Database](https://isbndb.com/apidocs)| |
-| ✅ | ✅ | [National Weather Service](https://www.weather.gov/documentation/services-web-api)| | 
-| ✅ | ✅ | [Open Movie Database](https://www.omdbapi.com)| |
-| ✅ | ❌ | [PokeAPI](https://pokeapi.co)| |
-| ✅ | ❌ | [Random User Generator ](https://randomuser.me)| |
-| ✅ | ✅ | [SpaceX — GraphQL Visual API](https://api.spacex.land) <br> [SpaceX — REST API](https://api.spacex.land/rest) <br> [SpaceX — Docs v4 (Latest)](https://github.com/r-spacex/SpaceX-API/tree/master/docs#rspacex-api-docs) <br> [SpaceX — Docs v3 (Depreciated)](https://docs.spacexdata.com)| |
-| ❌ | ❌ | [Star Trek API](http://stapi.co)| |
-| ✅ | ✅ | [Stock Photography](https://unsplash.com/developers)| |
-| ✅ | ❌ | [Sunrise/Sunset](https://sunrise-sunset.org/api)| |
-| ✅ | ❌ | [Text Casing / Number Conversion](https://www.dataaccess.com/webservicesserver/TextCasing.wso)| |
-| ✅ | ✅ | [The Cat API](https://thecatapi.com)| |
-| ✅ | ❌ | [The Met Collection](https://www.metmuseum.org/blogs/now-at-the-met/2018/met-collection-api)| |
-| ✅ | ✅ | [The Movie DB](https://www.themoviedb.org/settings/api)| |
-| ✅ | ✅ | [Twilio Look-up API](https://www.twilio.com/docs/lookup/api)| |
-| ✅ | ✅ | [Walmart](https://developer.walmart.com)| |
+| ✅ | ✅ | [AI Image Generation](https://generated.photos/api) | High-quality AI-generated headshot photos. |
+| ✅ | ❌ | [Chuck Norris Joke API](https://www.icndb.com/api) | Database of Chuck Norris jokes. |
+| ✅ | ✅ | [Congress](https://api.congress.gov/) | Database of public US Congress data. |
+| ✅ | ✅ | [Flight and Satellite Data](https://aviation-edge.com) | A variety of aero-/astronautic data. (e.g., flight tracker, flight schedules, satellite tracker) |
+| ✅ | ✅ | [ISBN Database](https://isbndb.com/apidocs) | Database of over 31 million book ISBN numbers. |
+| ✅ | ✅ | [National Weather Service](https://www.weather.gov/documentation/services-web-api) | NOAA weather data and alerts. | 
+| ✅ | ✅ | [Open Movie Database](https://www.omdbapi.com) | Database of IMDb film information |
+| ✅ | ❌ | [PokéAPI](https://pokeapi.co) | Extensive database of data from the Pokémon video game franchise. |
+| ✅ | ❌ | [Random User Generator ](https://randomuser.me) | Generate random, placeholder user data. (e.g., name, email, phone number) |
+| ✅ | ✅ | **SpaceX API** <br> [GraphQL Visual API](https://api.spacex.land) <br> [REST API](https://api.spacex.land/rest) <br> [Docs v4 (Latest)](https://github.com/r-spacex/SpaceX-API/tree/master/docs#rspacex-api-docs) <br> [Docs v3 (Depreciated)](https://docs.spacexdata.com) | <br> Visual SpaceX API query generator. <br> SpaceX REST API documentation. <br> Latest SpaceX API documentation. <br> Depreciated SpaceX API documentation |
+| ❌ | ❌ | [Star Trek API](http://stapi.co) | Extensive database of Star Trek data and information. |
+| ✅ | ✅ | [Stock Photography](https://unsplash.com/developers) | Database of photos with detailed metadata, useful for ML training. |
+| ✅ | ❌ | [Sunrise/Sunset](https://sunrise-sunset.org/api) | Time of sunset and sunrise for a given latitude and longitude. |
+| ✅ | ❌ | [Text Casing and Transformation](https://www.dataaccess.com/webservicesserver/TextCasing.wso) | Tools for text capitalization and transformation. |
+| ✅ | ✅ | [The Cat API](https://thecatapi.com) | Database of cat photos and data, indexed by breed. |
+| ✅ | ❌ | [The Met Collection](https://www.metmuseum.org/blogs/now-at-the-met/2018/met-collection-api) | Extensive database of the entire Met Museum's collection. |
+| ✅ | ✅ | [The Movie DB](https://www.themoviedb.org/documentation/api) | Database of film data. (e.g., release date, actors, reviews) |
+| ✅ | ✅ | [Twilio Look-up API](https://www.twilio.com/docs/lookup/api) | Basic information of phone numbers. |
+| ✅ | ✅ | [Walmart](https://developer.walmart.com) | Manage company data as a seller or supplier. <br> *\*Only available as a company, and after an application review.* |
 
-- - - -
+<br>
 
-| Useful Links | Description |
+## Useful Links
+| Site | Description |
 |:-------------|:------------|
-| [List of APIs](https://apilist.fun)| |
-| [AI Image Generation](https://generated.photos)| |
+| [API List](https://apilist.fun) | Massive database of publicly available APIs. |

--- a/publicApis.md
+++ b/publicApis.md
@@ -4,24 +4,30 @@
 
 - - - -
 
-| HTTPs? | API | Description | Auth/Key? |
-|:---:|:---|:---|:--:|
-|  |[Chuck Norris Joke API](http://www.icndb.com/api)| | |
-|  |[Congress](https://api.congress.gov/)| | |
-|  |[Flight and Satellite Data](https://aviation-edge.com)| | |
-|  |[ISBN Database](https://isbndb.com/apidocs)| | |
-|  |[List of APIs](https://apilist.fun)| | |
-|  |[National Weather Service](https://www.weather.gov/documentation/services-web-api)| | 
-|  |[Open Movie Database](http://www.omdbapi.com)| | |
-|  |[PokeAPI](https://pokeapi.co)| | |
-|  |[Random User Generator ](https://randomuser.me)| | |
-|  |[SpaceX — GraphQL Visual API](https://api.spacex.land) <br> [SpaceX — REST API](https://api.spacex.land/rest) <br> [SpaceX — Docs v4 (Latest)](https://github.com/r-spacex/SpaceX-API/tree/master/docs#rspacex-api-docs) <br> [SpaceX — Docs v3 (Depreciated)](https://docs.spacexdata.com)| | |
-|  |[Star Trek API](http://stapi.co)| | |
-|  |[Stock Photography](https://unsplash.com/developers)| | |
-|  |[Sunrise/Sunset](https://sunrise-sunset.org/api)| | |
-|  |[Text Casing / Number Conversion](http://www.dataaccess.com/webservicesserver/TextCasing.wso)| | |
-|  |[The Cat API](https://thecatapi.com)| | |
-|  |[The Met Collection](https://www.metmuseum.org/blogs/now-at-the-met/2018/met-collection-api)| | |
-|  |[The Movie DB](https://www.themoviedb.org/settings/api)| | |
-|  |[Twilio Look-up API](https://www.twilio.com/docs/lookup/api)| | |
-|  |[Walmart](https://developer.walmart.com)| | |
+| HTTPs? | Key Required? | API | Description |
+|:---:|:---:|:---|:--|
+| ✅ | ❌ | [Chuck Norris Joke API](https://www.icndb.com/api)| |
+| ✅ | ✅ | [Congress](https://api.congress.gov/)| |
+| ✅ | ✅ | [Flight and Satellite Data](https://aviation-edge.com)| |
+| ✅ | ✅ | [ISBN Database](https://isbndb.com/apidocs)| |
+| ✅ | ✅ | [National Weather Service](https://www.weather.gov/documentation/services-web-api)| | 
+| ✅ | ✅ | [Open Movie Database](https://www.omdbapi.com)| |
+| ✅ | ❌ | [PokeAPI](https://pokeapi.co)| |
+| ✅ | ❌ | [Random User Generator ](https://randomuser.me)| |
+| ✅ | ✅ | [SpaceX — GraphQL Visual API](https://api.spacex.land) <br> [SpaceX — REST API](https://api.spacex.land/rest) <br> [SpaceX — Docs v4 (Latest)](https://github.com/r-spacex/SpaceX-API/tree/master/docs#rspacex-api-docs) <br> [SpaceX — Docs v3 (Depreciated)](https://docs.spacexdata.com)| |
+| ❌ | ❌ | [Star Trek API](http://stapi.co)| |
+| ✅ | ✅ | [Stock Photography](https://unsplash.com/developers)| |
+| ✅ | ❌ | [Sunrise/Sunset](https://sunrise-sunset.org/api)| |
+| ✅ | ❌ | [Text Casing / Number Conversion](https://www.dataaccess.com/webservicesserver/TextCasing.wso)| |
+| ✅ | ✅ | [The Cat API](https://thecatapi.com)| |
+| ✅ | ❌ | [The Met Collection](https://www.metmuseum.org/blogs/now-at-the-met/2018/met-collection-api)| |
+| ✅ | ✅ | [The Movie DB](https://www.themoviedb.org/settings/api)| |
+| ✅ | ✅ | [Twilio Look-up API](https://www.twilio.com/docs/lookup/api)| |
+| ✅ | ✅ | [Walmart](https://developer.walmart.com)| |
+
+- - - -
+
+| Useful Links | Description |
+|:-------------|:------------|
+| [List of APIs](https://apilist.fun)| |
+| [AI Image Generation](https://generated.photos)| |

--- a/publicApis.md
+++ b/publicApis.md
@@ -2,13 +2,13 @@
 
 > The APIs below are accessible for use in assignments or personal projects where you need to interact with a 3rd party API.
 
-## Index
+# Index
 - [API List](#api-list)
 - [Useful Links](#useful-links)
 
 <br>
 
-## API List
+# API List
 | HTTPS? | Key Required? | API | Description |
 |:---:|:---:|:---|:--|
 | ✅ | ✅ | [AI Image Generation](https://generated.photos/api) | High-quality AI-generated headshot photos. |

--- a/publicApis.md
+++ b/publicApis.md
@@ -33,7 +33,7 @@
 
 <br>
 
-## Useful Links
+# Useful Links
 | Site | Description |
 |:-------------|:------------|
 | [API List](https://apilist.fun) | Massive database of publicly available APIs. |

--- a/publicApis.md
+++ b/publicApis.md
@@ -1,3 +1,9 @@
 # Public APIs
 
 > The APIs below are accessible for use in assignments or personal projects where you need to interact with a 3rd party API.
+
+- - - -
+
+| HTTPs? | API | Description | Auth/Key? |
+|:---:|:---|:---|:--:|
+|     |    |    |    |


### PR DESCRIPTION
I've transferred the existing API list from Canvas into a Markdown file. I also expanded upon the original table by including HTTPS compatibility, whether an API key is required, and a brief description for each API. Some changes were made to the existing items, listed here:

## Changelog

### Add link

**SpaceX API Docs v4 (Latest)**

-  https<nolink>://github.com/r-spacex/SpaceX-API/tree/master/docs#rspacex-api-docs 

---

### Move to different table

**AI Image Generation** *(https<nolink>://generated.photos/api)*

- Other Links &#10233; Public API List
	
	> The site has now made a dedicated API.

**List of APIs** *(https<nolink>://apilist.fun/)*
 
- Public API List &#10233; Other Links
	
	> I've moved this to "Other Links" because it's a database of APIs, rather than an API itself.

---

### Change page directory

**Congress API**

- https<nolink>://api.congress.gov/#/ &#10233; https<nolink>://api.congress.gov/

**The Movie DB**

- https<nolink>://www<nolink>.themoviedb.org/settings/api &#10233; https<nolink>://www<nolink>.themoviedb.org/documentation/api
	
	> I've changed this for ease of access. The "settings" directory requires the user to log in, whereas the "documentation" directory doesn't.

**List of APIs**

- https<nolink>://generated.photos &#10233; https<nolink>://generated.photos/api
	
	> The link has been changed to go directly to the new API page.
